### PR TITLE
Property annotation

### DIFF
--- a/controllers/AddController.js
+++ b/controllers/AddController.js
@@ -1,4 +1,3 @@
-angular.module('haklab').controller('AddController',function($scope){
+angular.module('haklab').controller('AddController', ['$scope', function($scope){
 
-
-});
+}]);

--- a/controllers/ContactController.js
+++ b/controllers/ContactController.js
@@ -1,5 +1,6 @@
 angular.module('haklab').controller('ContactController', ContactController);
 
+ContactController.$inject = ['$scope', 'UtilService'];
 
 function ContactController($scope, UtilService){
 

--- a/controllers/EventController.js
+++ b/controllers/EventController.js
@@ -1,5 +1,7 @@
 angular.module('haklab').controller('EventController', EventController);
 
+EventController.$inject = ['$scope', 'EventService'];
+
 function EventController($scope, EventService){
 
   EventService.getAll().then(function(data){

--- a/controllers/MainController.js
+++ b/controllers/MainController.js
@@ -1,6 +1,7 @@
 'use strict';
 angular.module('haklab').controller('MainController', MainController);
 
+MainController.$inject = ['$scope', 'WorkshopService', '$routeParams'];
 
 function MainController($scope, WorkshopService, $routeParams) {
 

--- a/controllers/WorkshopController.js
+++ b/controllers/WorkshopController.js
@@ -1,5 +1,7 @@
 angular.module('haklab').controller('WorkshopController', WorkshopController);
 
+WorkshopController.$inject = ['$scope', 'WorkshopService'];
+
 function WorkshopController($scope, WorkshopService){
     WorkshopService.getAll().then(function(data){
     $scope.radionice = data.data;

--- a/service/EventService.js
+++ b/service/EventService.js
@@ -1,6 +1,7 @@
 'use strict';
 angular.module('haklab').service('EventService', EventService);
 
+EventService.$inject = ['$http', 'CONFIG'];
 
 function EventService($http, CONFIG) {
 

--- a/service/RadioniceServis.js
+++ b/service/RadioniceServis.js
@@ -1,6 +1,7 @@
 'use strict';
 angular.module('haklab').service('RadioniceServis', RadioniceServis);
 
+RadioniceServis.$inject = ['$http'];
 
 function RadioniceServis($http) {
   var self = this;

--- a/service/UtilService.js
+++ b/service/UtilService.js
@@ -1,6 +1,7 @@
 'use strict';
 angular.module('haklab').service('UtilService', UtilService);
 
+UtilService.$inject = ['$http', 'CONFIG'];
 
 function UtilService($http, CONFIG) {
 

--- a/service/WorkshopService.js
+++ b/service/WorkshopService.js
@@ -1,6 +1,7 @@
 'use strict';
 angular.module('haklab').service('WorkshopService', ['$http', 'CONFIG', WorkshopService]);
 
+WorkshopService.$inject = ['$http', 'CONFIG'];
 
 function WorkshopService($http, CONFIG) {
 


### PR DESCRIPTION
To allow the minifiers to rename the function parameters and still be able to inject the right services, the function needs to be annotated with the $inject property.
